### PR TITLE
[Team-13 iOS Neo] redux 구조 변경

### DIFF
--- a/mobile/issue-tracker/issue-tracker.xcodeproj/project.pbxproj
+++ b/mobile/issue-tracker/issue-tracker.xcodeproj/project.pbxproj
@@ -33,6 +33,8 @@
 		BF7B7CD72696AFE400278518 /* UIColor+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7B7CD62696AFE400278518 /* UIColor+Extension.swift */; };
 		BF7DE027267A418D0019B519 /* LoginViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BF0A6C15266F5F8F000F3BC5 /* LoginViewController.storyboard */; };
 		BF87CBC12686FC40002F81FD /* URLRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF8C7FBE2682242B005ABB38 /* URLRouter.swift */; };
+		BF8AC85326AE7BE500D90C4C /* TokenAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF8AC85226AE7BE500D90C4C /* TokenAction.swift */; };
+		BF8AC85526AE7CAD00D90C4C /* AppStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF8AC85426AE7CAD00D90C4C /* AppStore.swift */; };
 		BF8C7F052678905C005ABB38 /* ClientId.plist in Resources */ = {isa = PBXBuildFile; fileRef = BF8C7F042678905C005ABB38 /* ClientId.plist */; };
 		BF8C7F3A267A5E7D005ABB38 /* UIStoryBoard+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFB399CD2671BB59002C6D80 /* UIStoryBoard+Extension.swift */; };
 		BF8C7F4D267A6131005ABB38 /* KeychainSwift in Frameworks */ = {isa = PBXBuildFile; productRef = BF8C7F4C267A6131005ABB38 /* KeychainSwift */; };
@@ -124,6 +126,8 @@
 		BF50FE65267FC3FC0084F73F /* UIAlertController+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIAlertController+Extension.swift"; sourceTree = "<group>"; };
 		BF50FE67268022950084F73F /* ASWebAuthPublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASWebAuthPublisher.swift; sourceTree = "<group>"; };
 		BF7B7CD62696AFE400278518 /* UIColor+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Extension.swift"; sourceTree = "<group>"; };
+		BF8AC85226AE7BE500D90C4C /* TokenAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenAction.swift; sourceTree = "<group>"; };
+		BF8AC85426AE7CAD00D90C4C /* AppStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStore.swift; sourceTree = "<group>"; };
 		BF8C7F042678905C005ABB38 /* ClientId.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = ClientId.plist; sourceTree = "<group>"; };
 		BF8C7F8A267B2C06005ABB38 /* LoginUITests2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginUITests2.swift; sourceTree = "<group>"; };
 		BF8C7FBE2682242B005ABB38 /* URLRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLRouter.swift; sourceTree = "<group>"; };
@@ -352,6 +356,8 @@
 			isa = PBXGroup;
 			children = (
 				BF9D0942269E204E009B6AA0 /* AppCoordinator.swift */,
+				BF8AC85426AE7CAD00D90C4C /* AppStore.swift */,
+				BF8AC85226AE7BE500D90C4C /* TokenAction.swift */,
 			);
 			path = Coordinator;
 			sourceTree = "<group>";
@@ -592,6 +598,7 @@
 				BFB399CB2671B387002C6D80 /* Endpoint.swift in Sources */,
 				BFA153E6269EE79000341A6D /* LoginViewCoordinator.swift in Sources */,
 				BF9D08F9269CC905009B6AA0 /* UITabBarItem+Extension.swift in Sources */,
+				BF8AC85326AE7BE500D90C4C /* TokenAction.swift in Sources */,
 				BFD75CFF26949C4E004695E9 /* LabelCell.swift in Sources */,
 				BF251D252695A6AE00834E33 /* IssueLabel.swift in Sources */,
 				BF0A6C12266F5F40000F3BC5 /* LoginViewModel.swift in Sources */,
@@ -622,6 +629,7 @@
 				BF0E36A22695AE0B00835E49 /* IssueListCollectionDataSource.swift in Sources */,
 				BF50FE66267FC3FC0084F73F /* UIAlertController+Extension.swift in Sources */,
 				BFA153FB269F401900341A6D /* TabBarCoordinator.swift in Sources */,
+				BF8AC85526AE7CAD00D90C4C /* AppStore.swift in Sources */,
 				BFB399CE2671BB59002C6D80 /* UIStoryBoard+Extension.swift in Sources */,
 				BF0A6BD8266F4EE5000F3BC5 /* SceneDelegate.swift in Sources */,
 				BFD2198E268EC02800FEF16C /* Issues.swift in Sources */,

--- a/mobile/issue-tracker/issue-tracker/AppCycle/SceneDelegate.swift
+++ b/mobile/issue-tracker/issue-tracker/AppCycle/SceneDelegate.swift
@@ -26,10 +26,12 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window?.rootViewController = navigationController
         window?.makeKeyAndVisible()
 
+        let appStore = AppStore(state: .init())
         appCoordinator = AppCoordinator(navigation: navigationController,
                                         dependency: .init(loginCoordinatorFactory: appDependency.makeLoginCoordinator,
                                                           tabBarCoordinatorFactory: appDependency.makeTabBarCoordinator))
-
+        appCoordinator?.dispatch = appStore.dispatch(_:)
+        appStore.updateState = appCoordinator?.update(with:)
         appCoordinator?.loadInitalView()
     }
 }

--- a/mobile/issue-tracker/issue-tracker/Coordinator/AppCoordinator.swift
+++ b/mobile/issue-tracker/issue-tracker/Coordinator/AppCoordinator.swift
@@ -17,7 +17,7 @@ final class AppCoordinator: Coordinator {
         var tabBarCoordinatorFactory: ((UINavigationController) -> TabBarCoordinator)
     }
 
-    private let loginCoordinator: LoginViewCoordinator
+    private var loginCoordinator: LoginViewCoordinator
     private let tabBarCoordinator: TabBarCoordinator
 
     init(navigation: UINavigationController = UINavigationController(),
@@ -37,7 +37,9 @@ final class AppCoordinator: Coordinator {
     }
 
     private func showLoginFlow() {
-        loginCoordinator.delegate = self
+        loginCoordinator.authenticated = {
+            self.showTabBarFlow()
+        }
         loginCoordinator.loadInitalView()
     }
 
@@ -50,11 +52,5 @@ final class AppCoordinator: Coordinator {
             return true
         }
         return toggle
-    }
-}
-
-extension AppCoordinator: LoginViewCoordinatorDelegate {
-    func completeLogin() {
-        showTabBarFlow()
     }
 }

--- a/mobile/issue-tracker/issue-tracker/Coordinator/AppCoordinator.swift
+++ b/mobile/issue-tracker/issue-tracker/Coordinator/AppCoordinator.swift
@@ -19,6 +19,9 @@ final class AppCoordinator: Coordinator {
 
     private var loginCoordinator: LoginViewCoordinator
     private let tabBarCoordinator: TabBarCoordinator
+    private var tokenState: Bool {
+        KeychainSwift().get("token")?.isEmpty ?? true
+    }
 
     init(navigation: UINavigationController = UINavigationController(),
          dependency: Dependency) {
@@ -29,7 +32,7 @@ final class AppCoordinator: Coordinator {
     }
 
     func loadInitalView() {
-        if isEmptyToken() {
+        if tokenState {
             showLoginFlow()
         } else {
             showTabBarFlow()
@@ -45,12 +48,5 @@ final class AppCoordinator: Coordinator {
 
     private func showTabBarFlow() {
         tabBarCoordinator.loadInitalView()
-    }
-
-    private func isEmptyToken() -> Bool {
-        guard let toggle = KeychainSwift().get("token")?.isEmpty else {
-            return true
-        }
-        return toggle
     }
 }

--- a/mobile/issue-tracker/issue-tracker/Coordinator/AppStore.swift
+++ b/mobile/issue-tracker/issue-tracker/Coordinator/AppStore.swift
@@ -1,0 +1,50 @@
+//
+//  AppStore.swift
+//  issue-tracker
+//
+//  Created by HOONHA CHOI on 2021/07/26.
+//
+
+import Foundation
+import Combine
+import KeychainSwift
+
+final class AppStore {
+
+    struct State {
+        var token: TokenAction = .initial
+    }
+
+    struct Reducer {
+        func reduce(action: TokenAction, state: inout State) {
+            switch action {
+            case .initial:
+                state.token = (KeychainSwift().get("token")?.isEmpty ?? true) ? .empty : .existent
+            case .empty:
+                state.token = .empty
+            case .completed, .existent:
+                state.token = .existent
+            }
+        }
+    }
+
+    private var reducer: Reducer {
+        return Reducer()
+    }
+
+    @Published private(set) var state: State
+    private var cancellable: AnyCancellable?
+
+    var updateState: ((AppCoordinator.TokenState) -> Void)?
+
+    init(state: State) {
+        self.state = state
+        cancellable = $state.sink(receiveValue: { [weak self] state in
+            self?.updateState?(AppCoordinator.TokenState(token: state.token))
+        })
+    }
+
+    func dispatch(_ action: TokenAction) {
+        reducer.reduce(action: action, state: &state)
+    }
+}

--- a/mobile/issue-tracker/issue-tracker/Coordinator/TokenAction.swift
+++ b/mobile/issue-tracker/issue-tracker/Coordinator/TokenAction.swift
@@ -1,0 +1,15 @@
+//
+//  AppAction.swift
+//  issue-tracker
+//
+//  Created by HOONHA CHOI on 2021/07/26.
+//
+
+import Foundation
+
+enum TokenAction {
+    case initial
+    case empty
+    case existent
+    case completed
+}

--- a/mobile/issue-tracker/issue-tracker/PresentationLayer/Login/LoginViewController.swift
+++ b/mobile/issue-tracker/issue-tracker/PresentationLayer/Login/LoginViewController.swift
@@ -11,7 +11,7 @@ import AuthenticationServices
 final class LoginViewController: UIViewController, StoryBoarded {
 
     var githubLoginHandler: ((ASWebAuthenticationPresentationContextProviding) -> Void)?
-    var authorizeCompleteHandler: (() -> Void)?
+    var authorizeCompleteHandler: ((TokenAction) -> Void)?
 
     override func viewDidLoad() {}
 
@@ -28,7 +28,7 @@ final class LoginViewController: UIViewController, StoryBoarded {
 
     func authorizeCompltion() {
         DispatchQueue.main.async { [weak self] in
-            self?.authorizeCompleteHandler?()
+            self?.authorizeCompleteHandler?(.completed)
             self?.dismiss(animated: true, completion: nil)
         }
     }

--- a/mobile/issue-tracker/issue-tracker/PresentationLayer/Login/LoginViewController.swift
+++ b/mobile/issue-tracker/issue-tracker/PresentationLayer/Login/LoginViewController.swift
@@ -8,14 +8,10 @@
 import UIKit
 import AuthenticationServices
 
-protocol LoginViewControllerDelegate: AnyObject {
-    func didFinishLogin()
-}
-
 final class LoginViewController: UIViewController, StoryBoarded {
 
     var githubLoginHandler: ((ASWebAuthenticationPresentationContextProviding) -> Void)?
-    weak var delegate: LoginViewControllerDelegate?
+    var authorizeCompleteHandler: (() -> Void)?
 
     override func viewDidLoad() {}
 
@@ -32,7 +28,7 @@ final class LoginViewController: UIViewController, StoryBoarded {
 
     func authorizeCompltion() {
         DispatchQueue.main.async { [weak self] in
-            self?.delegate?.didFinishLogin()
+            self?.authorizeCompleteHandler?()
             self?.dismiss(animated: true, completion: nil)
         }
     }

--- a/mobile/issue-tracker/issue-tracker/PresentationLayer/Login/LoginViewCoordinator.swift
+++ b/mobile/issue-tracker/issue-tracker/PresentationLayer/Login/LoginViewCoordinator.swift
@@ -11,15 +11,11 @@ protocol LoginViewCoordinatorDependencies {
     func makeLoginViewController() -> LoginViewController
 }
 
-protocol LoginViewCoordinatorDelegate: AnyObject {
-    func completeLogin()
-}
-
-final class LoginViewCoordinator: Coordinator {
+struct LoginViewCoordinator: Coordinator {
     var navigation: UINavigationController
+    var authenticated: (() -> Void)?
 
     private let loginViewControllerFactory: () -> LoginViewController
-    weak var delegate: LoginViewCoordinatorDelegate?
 
     init(navigation: UINavigationController,
          dependency: LoginViewCoordinatorDependencies) {
@@ -29,13 +25,9 @@ final class LoginViewCoordinator: Coordinator {
 
     func loadInitalView() {
         let loginViewController = loginViewControllerFactory()
-        loginViewController.delegate = self
+        loginViewController.authorizeCompleteHandler = {
+            self.authenticated?()
+        }
         navigation.setViewControllers([loginViewController], animated: true)
-    }
-}
-
-extension LoginViewCoordinator: LoginViewControllerDelegate {
-    func didFinishLogin() {
-        delegate?.completeLogin()
     }
 }

--- a/mobile/issue-tracker/issue-tracker/PresentationLayer/Login/LoginViewCoordinator.swift
+++ b/mobile/issue-tracker/issue-tracker/PresentationLayer/Login/LoginViewCoordinator.swift
@@ -13,7 +13,7 @@ protocol LoginViewCoordinatorDependencies {
 
 struct LoginViewCoordinator: Coordinator {
     var navigation: UINavigationController
-    var authenticated: (() -> Void)?
+    var authenticated: ((TokenAction) -> Void)?
 
     private let loginViewControllerFactory: () -> LoginViewController
 
@@ -25,9 +25,7 @@ struct LoginViewCoordinator: Coordinator {
 
     func loadInitalView() {
         let loginViewController = loginViewControllerFactory()
-        loginViewController.authorizeCompleteHandler = {
-            self.authenticated?()
-        }
+        loginViewController.authorizeCompleteHandler = authenticated
         navigation.setViewControllers([loginViewController], animated: true)
     }
 }


### PR DESCRIPTION
로그인 뷰 컨트롤러는 성공했다는 이벤트만 필요했기에 상태를 만들지 않고
클로저로 액션만 전달 하도록 변경했습니다

로그인 코디네이터 또한 이벤트만 전달만 하면 되기 때문에 클로저로 액선만 전달하도록 변경했고
앱코디네이터가 상태를 가지고 상태에 따라 화면이 변경되도록 수정했습니다!

참고 자료에서 AppStore에 state 있는데  ViewState 존재 이유를 몰랐었는데
리덕스는 새로운 state값을 만들어서 바꿔 return 할때 불변성 개념을 적용하고자 작성했었던 것 알게되었고
새로운 상태를 init로 생성해 주며 전달하기 까지  리덕스 개념과 흐름을 공부하는데 많이 도움이 되었습니다.

구조를 그려보면 이렇습니다!
<img width="1271" alt="스크린샷 2021-07-26 오후 8 39 54" src="https://user-images.githubusercontent.com/33626693/126982976-ea540421-a349-454f-9cf6-0a198d121500.png">
